### PR TITLE
feat: preserve comments in TS declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
         "esModuleInterop": true,
         "strict": true,
         "moduleResolution": "node",
-        "removeComments": true,
         "sourceMap": true,
         "noLib": false,
         "declaration": true,


### PR DESCRIPTION
Preserves comments in the distributed TS declarations (.d.ts files).
The comments contain valueable information about the APIs, so keeping them leads to a better DX.

For example:
![image](https://github.com/klaviyo/klaviyo-api-node/assets/18576413/3163c0a3-4faf-4313-af42-300d01a8e182)

Resolves https://github.com/klaviyo/klaviyo-api-node/issues/58.
