### PR TITLE
Eliminate require() in favor of import

### DIFF
--- a/api/accountsApi.ts
+++ b/api/accountsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/apis.ts
+++ b/api/apis.ts
@@ -1,3 +1,6 @@
+import querystring from 'querystring';
+import crypto from 'crypto';
+
 import {BackoffOptions} from "exponential-backoff";
 export * from './accountsApi';
 import { AccountsApi } from './accountsApi';
@@ -34,7 +37,7 @@ import { TemplatesApi } from './templatesApi';
 export * from './webhooksApi';
 import { WebhooksApi } from './webhooksApi';
 
-const axios = require('axios')
+import axios from 'axios';
 import {AxiosRequestConfig, AxiosResponse, AxiosHeaders, isAxiosError} from "axios";
 
 export { RequestFile } from '../model/models';
@@ -306,12 +309,6 @@ export class OAuthApi {
         redirectUrl: string,
     ): string {
         const url: URL = new URL(this.authorizeUrl)
-        let querystring
-        try {
-            querystring = require('node:querystring')
-        } catch (e) {
-            querystring = require('querystring')
-        }
 
         const params = {
             response_type: "code",
@@ -445,12 +442,6 @@ export namespace Pkce {
     }
 
     export function generateCodes() {
-        let crypto;
-        try {
-          crypto = require('node:crypto');
-        } catch (error) {
-            crypto = require('crypto');
-        }
         const base64URLEncode = (str) => {
             return str.toString('base64')
                 .replace(/\+/g, '-')

--- a/api/campaignsApi.ts
+++ b/api/campaignsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/catalogsApi.ts
+++ b/api/catalogsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/couponsApi.ts
+++ b/api/couponsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/dataPrivacyApi.ts
+++ b/api/dataPrivacyApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/eventsApi.ts
+++ b/api/eventsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/flowsApi.ts
+++ b/api/flowsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/formsApi.ts
+++ b/api/formsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/imagesApi.ts
+++ b/api/imagesApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/listsApi.ts
+++ b/api/listsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/metricsApi.ts
+++ b/api/metricsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/profilesApi.ts
+++ b/api/profilesApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/reportingApi.ts
+++ b/api/reportingApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/segmentsApi.ts
+++ b/api/segmentsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/tagsApi.ts
+++ b/api/tagsApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/templatesApi.ts
+++ b/api/templatesApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/api/webhooksApi.ts
+++ b/api/webhooksApi.ts
@@ -10,7 +10,7 @@
  */
 
 
-const axios = require('axios');
+import axios from 'axios'
 import {AxiosRequestConfig, AxiosResponse} from "axios";
 import { backOff, BackoffOptions } from 'exponential-backoff';
 import FormData from 'form-data'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "11.0.0",
             "license": "MIT",
             "dependencies": {
-                "axios": "^1.4.0",
+                "axios": "^1.7.5",
                 "exponential-backoff": "^3.1.1",
                 "form-data": "^4.0.0"
             },
@@ -1150,9 +1150,10 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/axios": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+            "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+            "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
         "clean": "rm -Rf node_modules/ *.js",
         "build": "tsc",
         "test": "jest",
-        "sample": "tsc --project tsconfig.sample.json && PK=$npm_config_pk node sample/dist/sample/sample.js"
+        "sample": "tsc --project tsconfig.sample.json && PK=$npm_config_pk node sample/dist/sample/sample.js",
+        "prepare": "npm run build"
     },
     "author": "Klaviyo-dev",
     "license": "MIT",
     "dependencies": {
-        "axios": "^1.4.0",
+        "axios": "^1.7.5",
         "exponential-backoff": "^3.1.1",
         "form-data": "^4.0.0"
     },


### PR DESCRIPTION
This PR fixes some legacy `require()`'s and runtime imports littered in the code base that were causing issues with Webpack (`TypeError: axios is not a function` at runtime) in a large ESM node 20 project that still includes some CommonJS package dependencies.  I suspect it may help address #53 

I don't expect it to be merged as is (I haven't updated the version or anything), but wanted to put it here in case the team wants to pull it in!

In addition to replacing `require` with `import`, this PR also:

- Bumps axios version to latest
- adds a prepare script to package.json so that my GitHub install via for my project is unblocked and `node_modules/klaviyo-node-api` folder has a `dist` folder 
  - This can probably be rolled back and isn't required to merge